### PR TITLE
Fix TF version and Interpreter warning

### DIFF
--- a/resources/03-quantization-and-pruning/quantization_and_pruning.ipynb
+++ b/resources/03-quantization-and-pruning/quantization_and_pruning.ipynb
@@ -36,7 +36,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow==2.19.0"
+        "!pip install tensorflow==2.19.0 ai-edge-litert"
       ]
     },
     {
@@ -50,6 +50,7 @@
         "We'll use the following libraries:\n",
         "\n",
         "- `tensorflow`: to do the actual ML\n",
+        "- `ai_edge_litert`: to convert the model to LiteRT format (formerly TensorFlow Lite)\n",
         "- `numpy`: for handling the dataset (MNIST)\n",
         "- `os`: for reading model files size\n",
         "- `tempfile`: to create temporary files (for saving gzipped models)\n",
@@ -65,6 +66,7 @@
       "outputs": [],
       "source": [
         "import tensorflow as tf\n",
+        "from ai_edge_litert.interpreter import Interpreter\n",
         "import numpy as np\n",
         "import os\n",
         "import tempfile\n",
@@ -302,7 +304,6 @@
       },
       "outputs": [],
       "source": [
-        "\n",
         "# Get the baseline accuracy\n",
         "_, ACCURACY['baseline Keras model'] = baseline_model.evaluate(test_images, test_labels)"
       ]
@@ -464,17 +465,7 @@
       },
       "outputs": [],
       "source": [
-        "ACCURACY['non quantized tflite'] = evaluate_tflite_model(FILE_NON_QUANTIZED_TFLITE, test_images, test_labels)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CplCOws3jaB0"
-      },
-      "outputs": [],
-      "source": [
+        "ACCURACY['non quantized tflite'] = evaluate_tflite_model(FILE_NON_QUANTIZED_TFLITE, test_images, test_labels)\n",
         "print_metric(ACCURACY, 'test accuracy')"
       ]
     },

--- a/resources/03-quantization-and-pruning/quantization_and_pruning.ipynb
+++ b/resources/03-quantization-and-pruning/quantization_and_pruning.ipynb
@@ -25,7 +25,7 @@
       "source": [
         "## Part 0. Preparation\n",
         "\n",
-        "Let's first install a fixed TensorFlow version."
+        "Let's first install a fixed TensorFlow version, the TensorFlow Model Optimization Toolkit, and the LiteRT package."
       ]
     },
     {
@@ -36,7 +36,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow==2.19.0 ai-edge-litert"
+        "!pip install tensorflow==2.19.0 tensorflow_model_optimization==0.8.0 ai-edge-litert "
       ]
     },
     {
@@ -566,28 +566,7 @@
         "id": "37oAb7PuXK36"
       },
       "source": [
-        "The [Tensorflow Model Optimization Toolkit](https://www.tensorflow.org/model_optimization) provides a [quantize_model()](https://www.tensorflow.org/model_optimization/api_docs/python/tfmot/quantization/keras/quantize_model) method to do this quickly and you will see that below. But first, let's install the toolkit into the notebook environment."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6WSt6OQGoNAt"
-      },
-      "outputs": [],
-      "source": [
-        "# Install the toolkit\n",
-        "!pip install tensorflow_model_optimization==0.8.0"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oYHmeMihYjnB"
-      },
-      "source": [
-        "You will build the baseline model again but this time, pass it into the `quantize_model()` method to indicate quantization aware training (note the `TODO`). Check the [documentation](https://www.tensorflow.org/model_optimization/guide/quantization/training_comprehensive_guide) for more information.\n",
+        "The [Tensorflow Model Optimization Toolkit](https://www.tensorflow.org/model_optimization) provides a [quantize_model()](https://www.tensorflow.org/model_optimization/api_docs/python/tfmot/quantization/keras/quantize_model) method to do this quickly. You will build the baseline model again but this time, pass it into the `quantize_model()` method to indicate quantization aware training (note the `TODO`). Check the [documentation](https://www.tensorflow.org/model_optimization/guide/quantization/training_comprehensive_guide) for more information.\n",
         "\n",
         "Take note that in case you decide to pass in a model that is already trained, then make sure to recompile before you continue training."
       ]


### PR DESCRIPTION
We should keep track of [LiteRT](https://github.com/google-ai-edge/LiteRT) as this seems to be the successor of TensorFlow Lite. But the docs of converting a TensorFlow model to TensorFlow Lite model still show our method of conversion. I only replaced the Interpreter for now.